### PR TITLE
Search path for python3 when launching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,3 @@ To run the script, simply invoke it from the command line:
 ```
 
 The first parameter is the source file (the WOFF) font, and the second parameter is the output file (in OTF format).
-
-### Note to OS X users
-The utility looks for `python3` in `/usr/bin/`. If you have it installed in `/usr/local/bin/` (use the command `which python3` to check), just replace `/usr/bin` with `/usr/local/bin` in the first line of the file.

--- a/woff2otf.py
+++ b/woff2otf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2012, Steffen Hanikel (https://github.com/hanikesn)
 #


### PR DESCRIPTION
This means the script can be invoked so long as Python 3 is
somewhere on the path, instead of assuming a fixed location.
